### PR TITLE
added the Instrument component to the MarketDataIncrementalRefresh message fields

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 {{$NEXT}}
 
-0.07      2023-05-01 08:53:22+00:00 UTC
-    - Accept instrument field in MarketDataIncrementalRefresh message
+0.08      2023-05-01 08:53:22+00:00 UTC
+    - Update: Add "Instrument" component to MarketDataIncrementalRefresh message schema
+
+0.07      2022-11-13 06:51:43+00:00 UTC
+    - Bugfix: Repetitive group not returning correct number of symbols
     
 0.06      2021-04-19 15:37:10+00:00 UTC
     - Bugfix: Repetitive group not returning correct number of symbols

--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+0.07      2023-05-01 08:53:22+00:00 UTC
+    - Accept instrument field in MarketDataIncrementalRefresh message
+    
 0.06      2021-04-19 15:37:10+00:00 UTC
     - Bugfix: Repetitive group not returning correct number of symbols
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -40,7 +40,7 @@ my %WriteMakefileArgs = (
     "Test::More" => "0.94",
     "Test::Warnings" => 0
   },
-  "VERSION" => "0.06",
+  "VERSION" => "0.08",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/share/FIX44.xml
+++ b/share/FIX44.xml
@@ -781,6 +781,7 @@
   </message>
   <message name='MarketDataIncrementalRefresh' msgtype='X' msgcat='app'>
    <field name='MDReqID' required='N' />
+   <component name='Instrument' required='Y' />
    <component name='MDIncGrp' required='Y' />
    <field name='ApplQueueDepth' required='N' />
    <field name='ApplQueueResolution' required='N' />


### PR DESCRIPTION
this change will add the "Instrument" field to the MarketDataIncrementalRefresh message fields as a required field.