### PR TITLE
remove unhandled import arguments

### DIFF
--- a/lib/Protocol/FIX/Parser.pm
+++ b/lib/Protocol/FIX/Parser.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use List::Util qw/first/;
-use Protocol::FIX qw/humanize/;
+use Protocol::FIX;
 use Protocol::FIX::TagsAccessor;
 use Protocol::FIX::MessageInstance;
 


### PR DESCRIPTION
Previous versions of perl allow a use or import call even if the import method doesn't exist. Future versions are intending to throw errors for calls to an undefined import method that includes arguments.

Remove the arguments to use lines when the import method does not exist.